### PR TITLE
Add mixing ratio plotting and homopause annotation

### DIFF
--- a/gitm_plot_alt_profile.py
+++ b/gitm_plot_alt_profile.py
@@ -92,10 +92,10 @@ try:
 except:
     vars = [0,1,2]
 
-# Only include neutral species (ions have a '+' in their names)
+# Only include neutral species (ions have a '+' and electrons are '[e-]')
 species_inds = [
     i for i, name in enumerate(header['vars'])
-    if name.startswith('[') and '+' not in name
+    if name.startswith('[') and '+' not in name and 'e-' not in name.lower()
 ]
 def _norm_species(name):
     return (


### PR DESCRIPTION
## Summary
- add `-mix` flag to plot mixing ratios for all species
- compute homopause altitude using N2/Ar ratio and annotate plot
- keep species legend within figure bounds

## Testing
- `python -m py_compile gitm_plot_alt_profile.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689d043f38bc832882927554642a2523