### PR TITLE
Remove file extensions from legend labels

### DIFF
--- a/gitm_plot_satellite.py
+++ b/gitm_plot_satellite.py
@@ -749,7 +749,7 @@ if args['oplot'] and len(alldata) > 1:
 
     file_handles = [pp.Line2D([], [], color='k', linestyle=file_linestyles[i])
                     for i in range(len(alldata))]
-    file_labels = [os.path.basename(f) for f in filelist]
+    file_labels = [os.path.splitext(os.path.basename(f))[0] for f in filelist]
     file_legend = ax.legend(file_handles, file_labels, loc='upper left',
                             frameon=False)
 


### PR DESCRIPTION
## Summary
- Strip file extensions from satellite plot legends for cleaner display

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68af44105d58832893c688d3b728432a